### PR TITLE
Fix basePath (baseUrl) resolution when using extends

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -63,7 +63,15 @@ export const loadConfig = (file: string): ITSConfig => {
   }
 
   if (ext) {
-    const parentConfig = loadConfig(resolve(dirname(file), ext));
+    const childConfigDirPath = dirname(file);
+    const parentConfigPath = resolve(childConfigDirPath, ext);
+    const parentConfigDirPath = dirname(parentConfigPath);
+    const parentConfig = loadConfig(parentConfigPath);
+
+    if (parentConfig.baseUrl) {
+      parentConfig.baseUrl = resolve(parentConfigDirPath, parentConfig.baseUrl);
+    }
+
     return {
       ...parentConfig,
       ...config,


### PR DESCRIPTION
`tsconfig-replace-paths@0.0.5` will incorrectly resolve `{ "baseUrl": "." }` in the `<reporoot>/tsconfig.json` file (extended from `<reporoot>/subdir/tsconfig.json`) to `<reporoot>/subdir/` instead of `<reporoot>/`, which makes import replacement fail outright or resolve to the wrong path.

The `path`s appearing in any TSConfig file should be resolved relative to final `baseUrl`, which `tsconfig-replace-paths` does correctly. Similarly, the `baseUrl` that appears in an _extended_ TSConfig file should be resolved _relative to the directory containing that (extended) file_, which `tsconfig-replace-paths` does incorrectly. This PR fixes that.

There are no unit tests, but it works in my [monorepo](https://github.com/Xunnamius/typescript-utils), which is using an [extended configuration](https://github.com/Xunnamius/typescript-utils/blob/main/tsconfig.json) located two directories up from the [extender](https://github.com/Xunnamius/typescript-utils/blob/main/packages/all-types/tsconfig.types.json). 