### PR TITLE
Handle file imports differently

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type": "git",
     "url": "https://github.com/jonkwheeler/tsconfig-replace-paths.git"
   },
+  "postinstall": "cd ./node_modules/tsconfig-replace-paths && yarn install && yarn build",
   "config": {
     "dirBuild": "./dist",
     "dirCommonjs": "./dist/commonjs",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "type": "git",
     "url": "https://github.com/jonkwheeler/tsconfig-replace-paths.git"
   },
-  "postinstall": "cd ./node_modules/tsconfig-replace-paths && yarn install && yarn build",
   "config": {
     "dirBuild": "./dist",
     "dirCommonjs": "./dist/commonjs",
@@ -33,7 +32,8 @@
     "nuke:build:rebuild": "yarn nuke:build && yarn build",
     "nuke:build": "rm -rf $npm_package_config_dirBuild",
     "nuke:node-nodules": "rm -rf node_modules",
-    "release": "yarn release-it"
+    "release": "yarn release-it",
+    "postinstall": "cd ./node_modules/tsconfig-replace-paths && yarn install && yarn build"
   },
   "bugs": {
     "url": "https://github.com/jonkwheeler/tsconfig-replace-paths/issues"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nuke:build": "rm -rf $npm_package_config_dirBuild",
     "nuke:node-nodules": "rm -rf node_modules",
     "release": "yarn release-it",
-    "postinstall": "cd ./node_modules/tsconfig-replace-paths && yarn install && yarn build"
+    "postinstall": "yarn install && yarn build"
   },
   "bugs": {
     "url": "https://github.com/jonkwheeler/tsconfig-replace-paths/issues"

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,11 +172,19 @@ const absToRel = (modulePath: string, outFile: string): string => {
       for (let i = 0; i < len; i += 1) {
         const apath = aliasPaths[i]
         const moduleSrc = resolve(apath, modulePathRel)
-        if (existsSync(moduleSrc) || exts.some(ext => existsSync(moduleSrc + ext))) {
-          const rel = toRelative(dirname(srcFile), moduleSrc)
-
+        for (const ext of exts) {
+          const moduleWithExt = moduleSrc + ext;
+          if (!existsSync(moduleWithExt)) {
+            continue
+          }
+          const rel = toRelative(dirname(srcFile), moduleWithExt).replace(/\.[^/.]+$/, "")
           replaceCount += 1
-
+          verboseLog(`\treplacing '${modulePath}' -> '${rel}' referencing ${relative(basePath, moduleWithExt)}`)
+          return rel;
+        }
+        if (existsSync(moduleSrc)) {
+          const rel = toRelative(dirname(srcFile), moduleSrc)
+          replaceCount += 1
           verboseLog(`\treplacing '${modulePath}' -> '${rel}' referencing ${relative(basePath, moduleSrc)}`)
           return rel
         }


### PR DESCRIPTION
I believe this logic is missing, to correctly handle the ambiguous case of a module reference that could be a file or a directory.