### PR TITLE
Pass patterns with forward-slashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import * as program from 'commander'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { sync } from 'globby'
-import { dirname, relative, resolve } from 'path'
+import { dirname, relative, resolve, posix, sep } from 'path'
 import { loadConfig } from './util'
 
 program
@@ -201,8 +201,11 @@ const replaceAlias = (text: string, outFile: string): string =>
     .replace(requireRegex, (orig, matched) => replaceImportStatement(orig, matched, outFile))
     .replace(importRegex, (orig, matched) => replaceImportStatement(orig, matched, outFile))
 
+// posix path for sync
+const posixOutPath = posix.join(...outPath.split(sep), `/**/*.{js,jsx,ts,tsx}`);
+
 // import relative to absolute path
-const files = sync(`${outPath}/**/*.{js,jsx,ts,tsx}`, {
+const files = sync(posixOutPath, {
   dot: true,
   noDir: true,
 } as any).map(x => resolve(x))


### PR DESCRIPTION
The `globby` library doesn't accept backward-slashes on `sync` function:
```
Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
```
Ref: https://github.com/sindresorhus/globby#api

This is the reason to the path replacement doesn't work properly on some Windows consoles/terminals. Windows uses backward slashes:
```
D:\git\tsconfig-replace-paths\dist/**/*.{js,jsx,ts,tsx}
```

This PR makes sure to always pass a pattern with forward-slashes:
```
D:/git/tsconfig-replace-paths/dist/**/*.{js,jsx,ts,tsx}
```