### PR TITLE
Fixes relative paths should keep ext when defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ const absToRel = (modulePath: string, outFile: string): string => {
           moduleSrc = moduleSrc.replace(moduleExt, '')
         }
         if (existsSync(moduleSrc) || exts.some(ext => existsSync(moduleSrc + ext))) {
-          const rel = toRelative(dirname(srcFile), moduleExt ? `${moduleSrc}.${moduleExt}` : moduleSrc)
+          const rel = toRelative(dirname(srcFile), moduleExt ? `${moduleSrc}${moduleExt}` : moduleSrc)
 
           replaceCount += 1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ const absToRel = (modulePath: string, outFile: string): string => {
           moduleSrc = moduleSrc.replace(moduleExt, '')
         }
         if (existsSync(moduleSrc) || exts.some(ext => existsSync(moduleSrc + ext))) {
-          const rel = toRelative(dirname(srcFile), moduleSrc)
+          const rel = toRelative(dirname(srcFile), moduleExt ? `${moduleSrc}.${moduleExt}` : moduleSrc)
 
           replaceCount += 1
 


### PR DESCRIPTION
Previous fix forgot to re-add the file ext back in.