### PR TITLE
fix '\' contained in globby.sync parrten always return []

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ const replaceAlias = (text: string, outFile: string): string =>
     .replace(importRegex, (orig, matched) => replaceImportStatement(orig, matched, outFile))
 
 // import relative to absolute path
-const files = sync(`${outPath}/**/*.{js,jsx,ts,tsx}`, {
+const files = sync(`${outPath.replaceAll('\\', '/')}/**/*.{js,jsx,ts,tsx}`, {
   dot: true,
   noDir: true,
 } as any).map(x => resolve(x))

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": false,
     "baseUrl": ".",
-    "lib": ["es5", "es6", "es2015", "es7", "es2016", "es2017"],
+    "lib": ["es5", "es6", "es2015", "es7", "es2016", "es2017", "ES2021.String"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist/commonjs",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": false,
     "baseUrl": ".",
-    "lib": ["es5", "es6", "es2015", "es7", "es2016", "es2017"],
+    "lib": ["es5", "es6", "es2015", "es7", "es2016", "es2017", "ES2021.String"],
     "module": "es6",
     "moduleResolution": "node",
     "outDir": "dist/esm",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
-    "lib": ["es5", "es6", "es7", "es2017", "dom"],
+    "lib": ["es5", "es6", "es7", "es2017", "dom", "ES2021.String"],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist",


### PR DESCRIPTION
replaceAll `\` in `outPath`, and add `ES2021.String` into tsconfig.compilerOptions.lib