### PR TITLE
Fix removing the extension from moduleSrc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ const absToRel = (modulePath: string, outFile: string): string => {
         let moduleSrc = resolve(apath, modulePathRel)
         const moduleExt = exts.find(ext => moduleSrc.endsWith(ext))
         if (moduleExt) {
-          moduleSrc = moduleSrc.replace(moduleExt, '')
+          moduleSrc = moduleSrc.substring(0, moduleSrc.length - moduleExt.length)
         }
         if (existsSync(moduleSrc) || exts.some(ext => existsSync(moduleSrc + ext))) {
           const rel = toRelative(dirname(srcFile), moduleExt ? `${moduleSrc}${moduleExt}` : moduleSrc)


### PR DESCRIPTION
Fix removing the extension from `moduleSrc`.

If the directory, or the project name, includes `.js`, e.g., `pdf.js`, `moduleSrc.replace(moduleExt, '')` doesn't work. It converts `/pdf.js/a.js` to `/pdf/a.js`.