### PR TITLE
Release 1.0.0: scanner-based replacement, one runtime dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Replace absolute paths to relative paths for package compilation.
 
+Requires Node.js 18 or later. The only runtime dependency is `typescript`.
+
 ## Getting Started
 
 Install `tsconfig-replace-paths` as a dev dependency:
@@ -20,9 +22,11 @@ npm install --save-dev tsconfig-replace-paths
 
 ```json
 "scripts": {
-  "build": "tsc --project tsconfig.json && tsconfig-replace-paths --project tsconfig.json"
+  "build": "tsc && tsconfig-replace-paths"
 }
 ```
+
+All flags are optional when run from the directory containing `tsconfig.json`.
 
 ## Options
 
@@ -34,6 +38,10 @@ npm install --save-dev tsconfig-replace-paths
 | `-v, --verbose` | log config, aliases, and each replacement | `false` |
 | `-q, --quiet` | suppress the summary line | `false` |
 | `-c, --check` | verify replacements without writing files; exits `1` if changes are needed | `false` |
+| `-h, --help` | print usage | |
+| `-V, --version` | print version | |
+
+Static imports, `export ... from`, `require(...)`, and dynamic `import(...)` specifiers are all rewritten. Output files with `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.mts`, and `.cts` extensions are processed.
 
 ## Programmatic API
 
@@ -96,11 +104,18 @@ tsconfig-replace-paths --project tsconfig.json --check
 
 Exits with code `1` when replacements are still needed.
 
+## Migrating to 1.0
+
+- Node.js 18 or later is required.
+- Dynamic `import('@alias/...')` specifiers are now rewritten too. If your ESM output intentionally kept aliased dynamic imports, pin to `0.0.x`.
+- `compilerOptions.baseUrl` is no longer required; `paths` without `baseUrl` resolve relative to the tsconfig file (TypeScript >= 4.1 semantics).
+- `extends` arrays (TypeScript 5.0) are now supported.
+- Aliases resolving to `.d.ts` files now rewrite to the declaration file instead of a broken `.js` path.
+
 ## Troubleshooting
 
 | Problem | Fix |
 | ------- | --- |
-| `compilerOptions.baseUrl is not set` | Add `baseUrl` to tsconfig |
 | `compilerOptions.paths is not set` | Add `paths` mappings |
 | ENOENT for `@tsconfig/*` extends | Upgrade to >= 0.0.15 |
 | Imports still point at `.ts` files | Upgrade to >= 0.0.18; ensure compiled `.js` output exists |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Exits with code `1` when replacements are still needed.
 
 | Problem | Fix |
 | ------- | --- |
+| `tsconfig not found at ...` | The error names the exact flag to run, e.g. `--project tsconfig.build.json` |
 | `compilerOptions.paths is not set` | Add `paths` mappings |
 | ENOENT for `@tsconfig/*` extends | Upgrade to >= 0.0.15 |
 | Imports still point at `.ts` files | Upgrade to >= 0.0.18; ensure compiled `.js` output exists |

--- a/bench/generate.ts
+++ b/bench/generate.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const root = path.resolve(__dirname, 'synthetic')
+const srcDir = path.join(root, 'src')
+const distDir = path.join(root, 'dist')
+
+const FILE_COUNT = Number(process.argv[2] || 2000)
+const ALIAS_IMPORTS_PER_FILE = 3
+const RELATIVE_IMPORTS_PER_FILE = 2
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+function writeBoth(relPath: string, content: string): void {
+  const srcFile = path.join(srcDir, relPath)
+  const distFile = path.join(distDir, relPath)
+  ensureDir(path.dirname(srcFile))
+  ensureDir(path.dirname(distFile))
+  fs.writeFileSync(srcFile, content)
+  fs.writeFileSync(distFile, content)
+}
+
+function main(): void {
+  fs.rmSync(root, { recursive: true, force: true })
+  ensureDir(srcDir)
+  ensureDir(distDir)
+
+  const dirs = ['utils', 'services', 'models', 'lib/deep/nested']
+  for (let d = 0; d < dirs.length; d += 1) {
+    for (let i = 0; i < 25; i += 1) {
+      writeBoth(path.join(dirs[d], `mod${i}.js`), `export const value${i} = ${i}\n`)
+    }
+  }
+
+  for (let i = 0; i < FILE_COUNT; i += 1) {
+    const lines: string[] = []
+    for (let a = 0; a < ALIAS_IMPORTS_PER_FILE; a += 1) {
+      const dir = dirs[(i + a) % dirs.length]
+      const mod = (i * 7 + a * 13) % 25
+      lines.push(`import { value${mod} } from '@alias/${dir === 'lib/deep/nested' ? 'deep' : dir}/mod${mod}'`)
+    }
+    for (let r = 0; r < RELATIVE_IMPORTS_PER_FILE; r += 1) {
+      lines.push(`import { value${r} } from './utils/mod${r}'`)
+    }
+    lines.push(`export const main${i} = ${i}`)
+    writeBoth(`feature${i % 20}/file${i}.js`, lines.join('\n') + '\n')
+  }
+
+  const tsconfig = {
+    compilerOptions: {
+      baseUrl: './src',
+      outDir: './dist',
+      rootDir: './src',
+      paths: {
+        '@alias/utils/*': ['utils/*'],
+        '@alias/services/*': ['services/*'],
+        '@alias/models/*': ['models/*'],
+        '@alias/deep/*': ['lib/deep/nested/*'],
+      },
+    },
+  }
+  fs.writeFileSync(path.join(root, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2))
+
+  console.log(`generated ${FILE_COUNT} feature files + 100 lib modules in ${root}`)
+}
+
+main()

--- a/bench/measure.cjs
+++ b/bench/measure.cjs
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const path = require('path')
+
+let existsSyncCalls = 0
+const realExistsSync = fs.existsSync
+fs.existsSync = function (p) {
+  existsSyncCalls += 1
+  return realExistsSync(p)
+}
+
+const { replacePaths } = require(path.join(__dirname, '..', 'dist', 'commonjs', 'api.js'))
+
+const start = process.hrtime.bigint()
+const result = replacePaths({ project: 'tsconfig.json', cwd: path.join(__dirname, 'synthetic'), quiet: true })
+const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+
+console.log('replacePaths: ' + elapsedMs.toFixed(0) + 'ms')
+console.log('replaced ' + result.replaceCount + ' paths in ' + result.changedFileCount + ' files')
+console.log('existsSync calls: ' + existsSyncCalls)

--- a/bench/measure.ts
+++ b/bench/measure.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs'
+import { replacePaths } from '../src/replace-paths'
+
+const root = __dirname + '/synthetic'
+
+let existsSyncCalls = 0
+const realExistsSync = fs.existsSync
+;(fs as { existsSync: typeof fs.existsSync }).existsSync = function (p: fs.PathLike): boolean {
+  existsSyncCalls += 1
+  return realExistsSync(p)
+}
+
+const start = process.hrtime.bigint()
+const result = replacePaths({ project: 'tsconfig.json', cwd: root, quiet: true })
+const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+
+console.log(`replacePaths: ${elapsedMs.toFixed(0)}ms`)
+console.log(`replaced ${result.replaceCount} paths in ${result.changedFileCount} files`)
+console.log(`existsSync calls: ${existsSyncCalls}`)

--- a/bench/parse-micro.cjs
+++ b/bench/parse-micro.cjs
@@ -1,0 +1,80 @@
+const fs = require('fs')
+const path = require('path')
+const ts = require('typescript')
+
+const distDir = path.join(__dirname, 'synthetic', 'dist')
+
+function listJs(dir, acc) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      listJs(p, acc)
+    } else if (p.endsWith('.js')) {
+      acc.push(p)
+    }
+  }
+  return acc
+}
+
+const files = listJs(distDir, [])
+const texts = files.map(function (f) {
+  return fs.readFileSync(f, 'utf8')
+})
+
+function time(label, fn) {
+  const start = process.hrtime.bigint()
+  const out = fn()
+  const ms = Number(process.hrtime.bigint() - start) / 1e6
+  console.log(label + ': ' + ms.toFixed(0) + 'ms' + (out !== undefined ? ' (' + out + ')' : ''))
+}
+
+time('createSourceFile setParentNodes=true', function () {
+  let n = 0
+  for (let i = 0; i < files.length; i += 1) {
+    ts.createSourceFile(files[i], texts[i], ts.ScriptTarget.Latest, true, ts.ScriptKind.JS)
+    n += 1
+  }
+  return n
+})
+
+time('createSourceFile setParentNodes=false', function () {
+  let n = 0
+  for (let i = 0; i < files.length; i += 1) {
+    ts.createSourceFile(files[i], texts[i], ts.ScriptTarget.Latest, false, ts.ScriptKind.JS)
+    n += 1
+  }
+  return n
+})
+
+time('ts.preProcessFile', function () {
+  let n = 0
+  let imports = 0
+  for (let i = 0; i < files.length; i += 1) {
+    const info = ts.preProcessFile(texts[i], true, true)
+    imports += info.importedFiles.length
+    n += 1
+  }
+  return n + ' files, ' + imports + ' imports'
+})
+
+time('prefix pre-filter (String.includes)', function () {
+  let hits = 0
+  for (let i = 0; i < files.length; i += 1) {
+    if (texts[i].includes('@alias/')) {
+      hits += 1
+    }
+  }
+  return hits + ' hits'
+})
+
+const sample = ts.preProcessFile(texts[0], true, true)
+console.log('sample importedFiles:', JSON.stringify(sample.importedFiles, null, 2))
+console.log('sample text:', JSON.stringify(texts[0].split('\n')[0]))
+
+const mixed = ts.preProcessFile(
+  "import a from '@alias/x'\nexport { b } from '@alias/y'\nconst c = require('@alias/z')\nconst d = import('@alias/dyn')\nconst e = \"@alias/not-an-import\"\n",
+  true,
+  true,
+)
+console.log('mixed detection:', JSON.stringify(mixed.importedFiles))

--- a/bench/prototype.cjs
+++ b/bench/prototype.cjs
@@ -1,0 +1,102 @@
+const fs = require('fs')
+const path = require('path')
+const ts = require('typescript')
+
+const root = path.join(__dirname, 'synthetic')
+
+function listFiles(dir, exts, acc) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      listFiles(p, exts, acc)
+    } else if (exts.indexOf(path.extname(entry.name)) !== -1) {
+      acc.push(p)
+    }
+  }
+  return acc
+}
+
+function freshFileSet(dir) {
+  return new Set(listFiles(dir, ['.js', '.jsx', '.ts', '.tsx', '.json'], []))
+}
+
+// Precompute file sets once; existsSync becomes a Set lookup.
+const srcFiles = freshFileSet(path.join(root, 'src'))
+const distFiles = freshFileSet(path.join(root, 'dist'))
+const knownFiles = new Set([...srcFiles, ...distFiles])
+
+let uncachedCalls = 0
+fs.existsSync = function (p) {
+  const key = path.resolve(String(p))
+  if (knownFiles.has(key)) {
+    return true
+  }
+  uncachedCalls += 1
+  return false
+}
+
+const { buildAliases, createAliasResolver } = require(path.join(__dirname, '..', 'dist', 'commonjs', 'resolve.js'))
+
+const tsconfig = JSON.parse(fs.readFileSync(path.join(root, 'tsconfig.json'), 'utf8'))
+const basePath = path.resolve(root, tsconfig.compilerOptions.baseUrl)
+const ctx = {
+  configFile: path.join(root, 'tsconfig.json'),
+  basePath: basePath,
+  usingSrcDir: path.join(root, 'src'),
+  outPath: path.join(root, 'dist'),
+  aliases: buildAliases(tsconfig.compilerOptions.paths, basePath),
+  verboseLog: function () {},
+}
+
+const resolver = createAliasResolver(ctx)
+const prefixes = ctx.aliases.map(function (a) {
+  return a.prefix
+})
+
+function replaceInText(text, outFile) {
+  const info = ts.preProcessFile(text, true, true)
+  const replacements = []
+  for (const ref of info.importedFiles) {
+    const matched = ref.fileName
+    const replacement = resolver.absToRel(matched, outFile)
+    if (replacement !== matched) {
+      replacements.push({ start: ref.pos + 1, end: ref.end - 1, text: replacement })
+    }
+  }
+  replacements.sort(function (a, b) {
+    return b.start - a.start
+  })
+  let result = text
+  for (const item of replacements) {
+    result = result.substring(0, item.start) + item.text + result.substring(item.end)
+  }
+  return result
+}
+
+const start = process.hrtime.bigint()
+const files = listFiles(ctx.outPath, ['.js', '.jsx', '.ts', '.tsx'], [])
+let changedFileCount = 0
+
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8')
+  let hasPrefix = false
+  for (const prefix of prefixes) {
+    if (text.indexOf(prefix) !== -1) {
+      hasPrefix = true
+      break
+    }
+  }
+  if (!hasPrefix) {
+    continue
+  }
+  const newText = replaceInText(text, file)
+  if (newText !== text) {
+    changedFileCount += 1
+  }
+}
+
+const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+console.log('optimized pipeline: ' + elapsedMs.toFixed(0) + 'ms')
+console.log('replaced ' + resolver.getReplaceCount() + ' paths in ' + changedFileCount + ' files')
+console.log('existsSync fallthrough calls (cache misses): ' + uncachedCalls)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
-    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json && node -e \"require('fs').writeFileSync('dist/esm/package.json', JSON.stringify({ type: 'module' }))\"",
     "build": "pnpm run build:esm && pnpm run build:cjs",
     "prepublishOnly": "pnpm run build",
     "test": "pnpm run build && tsx --test tests/run-fixtures.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig-replace-paths",
-  "version": "0.0.18",
+  "version": "1.0.0",
   "description": "Replace absolute paths to relative paths for package compilation",
   "author": "Jon Wheeler <jon.k.wheeler@gmail.com>",
   "license": "MIT",
@@ -9,15 +9,21 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/commonjs/index.js"
     },
     "./api": {
+      "types": "./dist/esm/api.d.ts",
       "import": "./dist/esm/api.js",
-      "require": "./dist/commonjs/api.js",
-      "types": "./dist/esm/api.d.ts"
-    }
+      "require": "./dist/commonjs/api.js"
+    },
+    "./package.json": "./package.json"
   },
+  "engines": {
+    "node": ">=18"
+  },
+  "sideEffects": false,
   "bin": {
     "tsconfig-replace-paths": "dist/commonjs/index.js"
   },
@@ -74,9 +80,6 @@
     "transform"
   ],
   "dependencies": {
-    "commander": "^3.0.2",
-    "globby": "^10.0.1",
-    "json5": "^2.2.3",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,6 @@ importers:
 
   .:
     dependencies:
-      commander:
-        specifier: ^3.0.2
-        version: 3.0.2
-      globby:
-        specifier: ^10.0.1
-        version: 10.0.2
-      json5:
-        specifier: ^2.2.3
-        version: 2.2.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -315,18 +306,11 @@ packages:
   '@tsconfig/node16@16.1.8':
     resolution: {integrity: sha512-T/CfdwFry660WjZor56z0F3pxeCllt8KOxWcHFW6ZEuULKUObTDEMdgtctyuJPxwqyWDsvHRfxHaJ4FIICyoqQ==}
 
-  '@types/glob@7.2.0':
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
-
-  '@types/minimatch@6.0.0':
-    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
-    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
@@ -477,10 +461,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -496,10 +476,6 @@ packages:
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
-
-  brace-expansion@5.0.9:
-    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
-    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -583,9 +559,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@3.0.2:
-    resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -973,10 +946,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  globby@10.0.2:
-    resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
-    engines: {node: '>=8'}
-
   globby@11.0.4:
     resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
     engines: {node: '>=10'}
@@ -1327,11 +1296,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -1423,10 +1387,6 @@ packages:
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
-
-  minimatch@10.2.6:
-    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -2336,20 +2296,11 @@ snapshots:
 
   '@tsconfig/node16@16.1.8': {}
 
-  '@types/glob@7.2.0':
-    dependencies:
-      '@types/minimatch': 6.0.0
-      '@types/node': 20.19.43
-
   '@types/json-schema@7.0.15': {}
 
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 20.19.43
-
-  '@types/minimatch@6.0.0':
-    dependencies:
-      minimatch: 10.2.6
 
   '@types/node@20.19.43':
     dependencies:
@@ -2533,8 +2484,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@4.0.4: {}
-
   base64-js@1.5.1: {}
 
   before-after-hook@2.2.3: {}
@@ -2560,10 +2509,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@5.0.9:
-    dependencies:
-      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -2643,8 +2588,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@3.0.2: {}
 
   concat-map@0.0.1: {}
 
@@ -3202,17 +3145,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globby@10.0.2:
-    dependencies:
-      '@types/glob': 7.2.0
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      glob: 7.2.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
-
   globby@11.0.4:
     dependencies:
       array-union: 2.1.0
@@ -3562,8 +3494,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json5@2.2.3: {}
-
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -3643,10 +3573,6 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-response@1.0.1: {}
-
-  minimatch@10.2.6:
-    dependencies:
-      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-export { loadConfig, mapPaths } from './config'
-export type { IRawTSConfig, ITSConfig } from './config'
-export { replacePaths } from './replace-paths'
-export type { AliasEntry, ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types'
+export { loadConfig, mapPaths } from './config.js'
+export type { IRawTSConfig, ITSConfig } from './config.js'
+export { replacePaths } from './replace-paths.js'
+export type { AliasEntry, ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types.js'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,23 @@
-import * as program from 'commander'
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { parseArgs } from 'util'
 import { replacePaths } from './replace-paths'
+
+const HELP_TEXT = `
+Usage: tsconfig-replace-paths [options]
+
+Options:
+  -p, --project <file>  path to tsconfig.json (default: tsconfig.json)
+  -s, --src <path>      source root path (overrides tsconfig rootDir)
+  -o, --out <path>      output root path (overrides tsconfig outDir)
+  -v, --verbose         output logs
+  -q, --quiet           only print the summary line
+  -c, --check           verify paths without writing files
+  -h, --help            show this help
+  -V, --version         show version
+
+  $ tsconfig-replace-paths -p tsconfig.json
+`
 
 function readPackageVersion(): string {
   const packageJsonPath = join(__dirname, '..', '..', 'package.json')
@@ -9,43 +25,62 @@ function readPackageVersion(): string {
   return packageJson.version
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 export function runCli(argv: string[]): void {
-  program
-    .version(readPackageVersion())
-    .option('-p, --project <file>', 'path to tsconfig.json')
-    .option('-s, --src <path>', 'source root path')
-    .option('-o, --out <path>', 'output root path')
-    .option('-v, --verbose', 'output logs')
-    .option('-q, --quiet', 'only print the summary line')
-    .option('-c, --check', 'verify paths without writing files')
+  let values: ReturnType<typeof parseCliArgs>
 
-  program.on('--help', function () {
-    console.log(`
-  $ tsconfig-replace-paths -p tsconfig.json
-`)
-  })
-
-  program.parse(argv)
-
-  const opts = program as {
-    project?: string
-    src?: string
-    out?: string
-    verbose?: boolean
-    quiet?: boolean
-    check?: boolean
-  }
-
-  const result = replacePaths({
-    project: opts.project,
-    src: opts.src,
-    out: opts.out,
-    verbose: opts.verbose,
-    quiet: opts.quiet,
-    check: opts.check,
-  })
-
-  if (result.checkFailed) {
+  try {
+    values = parseCliArgs(argv)
+  } catch (err) {
+    console.error(errorMessage(err))
+    console.error(HELP_TEXT)
     process.exit(1)
   }
+
+  if (values.help) {
+    console.log(HELP_TEXT)
+    return
+  }
+
+  if (values.version) {
+    console.log(readPackageVersion())
+    return
+  }
+
+  try {
+    const result = replacePaths({
+      project: values.project,
+      src: values.src,
+      out: values.out,
+      verbose: values.verbose,
+      quiet: values.quiet,
+      check: values.check,
+    })
+
+    if (result.checkFailed) {
+      process.exit(1)
+    }
+  } catch (err) {
+    console.error(errorMessage(err))
+    process.exit(1)
+  }
+}
+
+function parseCliArgs(argv: string[]) {
+  return parseArgs({
+    args: argv.slice(2),
+    options: {
+      project: { type: 'string', short: 'p' },
+      src: { type: 'string', short: 's' },
+      out: { type: 'string', short: 'o' },
+      verbose: { type: 'boolean', short: 'v' },
+      quiet: { type: 'boolean', short: 'q' },
+      check: { type: 'boolean', short: 'c' },
+      help: { type: 'boolean', short: 'h' },
+      version: { type: 'boolean', short: 'V' },
+    },
+  }).values
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { parseArgs } from 'util'
-import { replacePaths } from './replace-paths'
+import { replacePaths } from './replace-paths.js'
 
 const HELP_TEXT = `
 Usage: tsconfig-replace-paths [options]

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,8 @@
-const path = require('path')
-const fs = require('fs')
-const JSON5 = require('json5')
+import * as path from 'path'
+import * as ts from 'typescript'
 
 export interface IRawTSConfig {
-  extends?: string
+  extends?: string | string[]
   compilerOptions?: {
     baseUrl?: string
     outDir?: string
@@ -31,73 +30,43 @@ export function mapPaths(
   return dest
 }
 
-function resolveConfigFile(configDir: string, extendsPath: string): string {
-  const relativeCandidate = path.resolve(configDir, extendsPath)
-  const currentExtension = path.extname(relativeCandidate)
-
-  let localConfigFile = path.format({
-    name: relativeCandidate,
-    ext: currentExtension === '' ? '.json' : '',
-  })
-
-  if (/\.json\.json$/.test(localConfigFile)) {
-    localConfigFile = localConfigFile.replace(/\.json\.json$/, '.json')
-  }
-
-  if (fs.existsSync(localConfigFile)) {
-    return localConfigFile
-  }
-
-  try {
-    return require.resolve(extendsPath, { paths: [configDir] })
-  } catch {
-    return localConfigFile
+function createParseHost(): ts.ParseConfigHost {
+  return {
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    // Skip input-file globbing; only compilerOptions are needed here.
+    readDirectory: function () {
+      return []
+    },
+    fileExists: function (fileName: string) {
+      return ts.sys.fileExists(fileName)
+    },
+    readFile: function (fileName: string) {
+      return ts.sys.readFile(fileName)
+    },
   }
 }
 
 export function loadConfig(file: string): ITSConfig {
-  const fileToParse = fs.readFileSync(file)
-  const parsedJsonFile = JSON5.parse(fileToParse)
+  const readResult = ts.readConfigFile(file, ts.sys.readFile)
+  if (readResult.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(readResult.error.messageText, '\n'))
+  }
 
-  const {
-    extends: extendsPath,
-    compilerOptions: { baseUrl, outDir, rootDir, paths } = {
-      baseUrl: undefined,
-      outDir: undefined,
-      rootDir: undefined,
-      paths: undefined,
-    },
-  } = parsedJsonFile as IRawTSConfig
+  const parsed = ts.parseJsonConfigFileContent(readResult.config, createParseHost(), path.dirname(file), undefined, file)
+  const options = parsed.options
 
   const config: ITSConfig = {}
-  if (baseUrl) {
-    config.baseUrl = baseUrl
+  if (options.baseUrl) {
+    config.baseUrl = options.baseUrl
   }
-  if (outDir) {
-    config.outDir = outDir
+  if (options.outDir) {
+    config.outDir = options.outDir
   }
-  if (rootDir) {
-    config.rootDir = rootDir
+  if (options.rootDir) {
+    config.rootDir = options.rootDir
   }
-  if (paths) {
-    config.paths = paths
+  if (options.paths) {
+    config.paths = options.paths
   }
-  if (extendsPath) {
-    const childConfigDirPath = path.dirname(file)
-    const parentExtendedConfigFile = resolveConfigFile(childConfigDirPath, extendsPath)
-    const parentConfigDirPath = path.dirname(parentExtendedConfigFile)
-
-    const parentConfig = loadConfig(parentExtendedConfigFile)
-
-    if (parentConfig.baseUrl) {
-      parentConfig.baseUrl = path.resolve(parentConfigDirPath, parentConfig.baseUrl)
-    }
-
-    return {
-      ...parentConfig,
-      ...config,
-    }
-  }
-
   return config
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
 
-import { runCli } from './cli'
+import { runCli } from './cli.js'
 
 runCli(process.argv)

--- a/src/replace-paths.ts
+++ b/src/replace-paths.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript'
-import { readFileSync, readdirSync, writeFileSync } from 'fs'
-import { dirname, extname, join, resolve } from 'path'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs'
+import { dirname, extname, join, relative, resolve } from 'path'
 import { loadConfig } from './config'
 import { buildAliases, createAliasResolver } from './resolve'
 import { ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types'
@@ -15,6 +15,22 @@ function createVerboseLog(verbose: boolean, quiet: boolean): (...args: unknown[]
   }
 }
 
+function listConfigCandidates(configFile: string, cwd: string): string[] {
+  const configDir = dirname(configFile)
+  try {
+    return readdirSync(configDir)
+      .filter(function (entry) {
+        return /^tsconfig.*\.json$/.test(entry)
+      })
+      .sort()
+      .map(function (entry) {
+        return relative(cwd, join(configDir, entry))
+      })
+  } catch {
+    return []
+  }
+}
+
 function buildContext(options: ReplacePathsOptions): ResolvedContext {
   const cwd = options.cwd || process.cwd()
   const project = options.project || 'tsconfig.json'
@@ -22,6 +38,17 @@ function buildContext(options: ReplacePathsOptions): ResolvedContext {
   const verboseLog = createVerboseLog(Boolean(options.verbose), Boolean(options.quiet))
 
   verboseLog(`Using tsconfig: ${configFile}`)
+
+  if (!existsSync(configFile)) {
+    const candidates = listConfigCandidates(configFile, cwd)
+    let hint = ''
+    if (candidates.length === 1) {
+      hint = ` Found: ${candidates[0]} — use --project ${candidates[0]}`
+    } else if (candidates.length > 1) {
+      hint = ` Found: ${candidates.join(', ')} — pass one with --project (e.g. --project ${candidates[0]})`
+    }
+    throw new Error(`tsconfig not found at ${configFile}.${hint}`)
+  }
 
   const returnedTsConfig = loadConfig(configFile)
   const { baseUrl, paths, outDir: tsConfigOutDir, rootDir: tsConfigRootDir } = returnedTsConfig

--- a/src/replace-paths.ts
+++ b/src/replace-paths.ts
@@ -1,9 +1,9 @@
 import * as ts from 'typescript'
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs'
 import { dirname, extname, join, relative, resolve } from 'path'
-import { loadConfig } from './config'
-import { buildAliases, createAliasResolver } from './resolve'
-import { ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types'
+import { loadConfig } from './config.js'
+import { buildAliases, createAliasResolver } from './resolve.js'
+import { ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types.js'
 
 const OUTPUT_FILE_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts']
 

--- a/src/replace-paths.ts
+++ b/src/replace-paths.ts
@@ -1,10 +1,11 @@
 import * as ts from 'typescript'
-import { readFileSync, writeFileSync } from 'fs'
-import { sync } from 'globby'
-import { dirname, resolve } from 'path'
+import { readFileSync, readdirSync, writeFileSync } from 'fs'
+import { dirname, extname, join, resolve } from 'path'
 import { loadConfig } from './config'
 import { buildAliases, createAliasResolver } from './resolve'
 import { ReplacePathsOptions, ReplacePathsResult, ResolvedContext } from './types'
+
+const OUTPUT_FILE_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts']
 
 function createVerboseLog(verbose: boolean, quiet: boolean): (...args: unknown[]) => void {
   return function (...args: unknown[]): void {
@@ -23,37 +24,17 @@ function buildContext(options: ReplacePathsOptions): ResolvedContext {
   verboseLog(`Using tsconfig: ${configFile}`)
 
   const returnedTsConfig = loadConfig(configFile)
-  const {
-    baseUrl,
-    paths,
-    outDir: tsConfigOutDir = '',
-    rootDir: tsConfigRootDir = cwd,
-  } = returnedTsConfig
-
-  if (!options.src && tsConfigRootDir === '') {
-    console.error('Whoops! Please set compilerOptions.rootDir in your tsconfig or supply a flag')
-    throw new Error('--- exiting tsconfig-replace-paths due to parameters missing ---')
-  }
-
-  if (!options.out && tsConfigOutDir === '') {
-    console.error('Whoops! Please set compilerOptions.outDir in your tsconfig or supply a flag')
-    throw new Error('--- exiting tsconfig-replace-paths due to parameters missing ---')
-  }
+  const { baseUrl, paths, outDir: tsConfigOutDir, rootDir: tsConfigRootDir } = returnedTsConfig
 
   let usingSrcDir: string
   if (options.src) {
     verboseLog('Using flag --src')
     usingSrcDir = resolve(cwd, options.src)
-  } else {
+  } else if (tsConfigRootDir) {
     verboseLog('Using compilerOptions.rootDir from your tsconfig')
-    usingSrcDir = resolve(cwd, tsConfigRootDir)
-  }
-
-  if (!usingSrcDir) {
-    console.error(
-      `Whoops! rootDir must be specified in your project => --project ${project}, or flagged with directory => --src './path'`,
-    )
-    throw new Error('--- exiting tsconfig-replace-paths due to parameters missing ---')
+    usingSrcDir = tsConfigRootDir
+  } else {
+    usingSrcDir = cwd
   }
 
   verboseLog(`Using src: ${usingSrcDir}`)
@@ -62,38 +43,29 @@ function buildContext(options: ReplacePathsOptions): ResolvedContext {
   if (options.out) {
     verboseLog('Using flag --out')
     usingOutDir = resolve(cwd, options.out)
-  } else {
+  } else if (tsConfigOutDir) {
     verboseLog('Using compilerOptions.outDir from your tsconfig')
-    usingOutDir = resolve(cwd, tsConfigOutDir)
-  }
-
-  if (!usingOutDir) {
-    console.error(
-      `Whoops! outDir must be specified in your project => --project ${project}, or flagged with directory => --out './path'`,
+    usingOutDir = tsConfigOutDir
+  } else {
+    throw new Error(
+      `outDir must be specified in your project => --project ${project}, or flagged with directory => --out './path'`,
     )
-    throw new Error('--- exiting tsconfig-replace-paths due to parameters missing ---')
   }
 
   verboseLog(`Using out: ${usingOutDir}`)
 
-  if (!baseUrl) {
-    throw new Error('compilerOptions.baseUrl is not set')
-  }
   if (!paths) {
     throw new Error('compilerOptions.paths is not set')
   }
 
-  verboseLog(`baseUrl: ${baseUrl}`)
+  const configDir = dirname(configFile)
+  const basePath = baseUrl ? resolve(configDir, baseUrl) : configDir
+
+  verboseLog(`baseUrl: ${baseUrl || '(unset, relative to tsconfig)'}`)
   verboseLog(`rootDir: ${usingSrcDir}`)
   verboseLog(`outDir: ${usingOutDir}`)
   verboseLog(`paths: ${JSON.stringify(paths, null, 2)}`)
-
-  const configDir = dirname(configFile)
-  const basePath = resolve(configDir, baseUrl)
-  const outPath = usingOutDir || resolve(basePath, usingOutDir)
-
   verboseLog(`basePath: ${basePath}`)
-  verboseLog(`outPath: ${outPath}`)
 
   const aliases = buildAliases(paths, basePath)
   verboseLog(`aliases: ${JSON.stringify(aliases, null, 2)}`)
@@ -102,75 +74,92 @@ function buildContext(options: ReplacePathsOptions): ResolvedContext {
     configFile: configFile,
     basePath: basePath,
     usingSrcDir: usingSrcDir,
-    outPath: outPath,
+    outPath: usingOutDir,
     aliases: aliases,
     verboseLog: verboseLog,
   }
 }
 
-function getScriptKind(fileName: string): ts.ScriptKind {
-  if (fileName.endsWith('.tsx') || fileName.endsWith('.jsx')) {
-    return ts.ScriptKind.TSX
+function walkOutputFiles(dir: string, acc: string[]): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true })
+
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i]
+    const entryPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walkOutputFiles(entryPath, acc)
+    } else if (OUTPUT_FILE_EXTS.indexOf(extname(entry.name)) !== -1) {
+      acc.push(entryPath)
+    }
   }
-  if (fileName.endsWith('.ts')) {
-    return ts.ScriptKind.TS
+
+  return acc
+}
+
+function hasAnyPrefix(text: string, prefixes: string[]): boolean {
+  for (let i = 0; i < prefixes.length; i += 1) {
+    if (text.indexOf(prefixes[i]) !== -1) {
+      return true
+    }
   }
-  return ts.ScriptKind.JS
+  return false
+}
+
+interface Replacement {
+  start: number
+  end: number
+  text: string
+}
+
+function findClosingQuote(text: string, openPos: number): number {
+  const quote = text.charAt(openPos)
+  let i = openPos + 1
+  while (i < text.length) {
+    const ch = text.charAt(i)
+    if (ch === '\\') {
+      i += 2
+      continue
+    }
+    if (ch === quote) {
+      return i
+    }
+    i += 1
+  }
+  return -1
 }
 
 function collectReplacements(
-  sourceFile: ts.SourceFile,
+  text: string,
   outFile: string,
   absToRel: (modulePath: string, outFile: string) => string,
-): Array<{ start: number; end: number; text: string }> {
-  const replacements: Array<{ start: number; end: number; text: string }> = []
+): Replacement[] {
+  const replacements: Replacement[] = []
+  const refs = ts.preProcessFile(text, true, true).importedFiles
 
-  function visit(node: ts.Node): void {
-    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
-      const spec = node.moduleSpecifier
-      if (spec && ts.isStringLiteral(spec)) {
-        const matched = spec.text
-        const replacement = absToRel(matched, outFile)
-        if (replacement !== matched) {
-          replacements.push({
-            start: spec.getStart(sourceFile) + 1,
-            end: spec.getEnd() - 1,
-            text: replacement,
-          })
-        }
-      }
+  for (let i = 0; i < refs.length; i += 1) {
+    const ref = refs[i]
+    const matched = ref.fileName
+    const replacement = absToRel(matched, outFile)
+    if (replacement === matched) {
+      continue
     }
 
-    if (
-      ts.isCallExpression(node) &&
-      node.expression.kind === ts.SyntaxKind.Identifier &&
-      (node.expression as ts.Identifier).text === 'require' &&
-      node.arguments.length > 0 &&
-      ts.isStringLiteral(node.arguments[0])
-    ) {
-      const arg = node.arguments[0]
-      const matched = arg.text
-      const replacement = absToRel(matched, outFile)
-      if (replacement !== matched) {
-        replacements.push({
-          start: arg.getStart(sourceFile) + 1,
-          end: arg.getEnd() - 1,
-          text: replacement,
-        })
-      }
+    // ref.end is unreliable (computed from the unescaped specifier), so the
+    // closing quote is re-derived from ref.pos, which always points at the
+    // opening quote.
+    const start = ref.pos + 1
+    const end = findClosingQuote(text, ref.pos)
+    if (end === -1 || text.substring(start, end) !== matched) {
+      continue
     }
 
-    ts.forEachChild(node, visit)
+    replacements.push({ start: start, end: end, text: replacement })
   }
 
-  visit(sourceFile)
   return replacements
 }
 
-function applyReplacements(
-  text: string,
-  replacements: Array<{ start: number; end: number; text: string }>,
-): string {
+function applyReplacements(text: string, replacements: Replacement[]): string {
   replacements.sort(function (a, b) {
     return b.start - a.start
   })
@@ -183,27 +172,15 @@ function applyReplacements(
   return result
 }
 
-function replaceAliasInText(
-  text: string,
-  outFile: string,
-  absToRel: (modulePath: string, outFile: string) => string,
-): string {
-  const sourceFile = ts.createSourceFile(outFile, text, ts.ScriptTarget.Latest, true, getScriptKind(outFile))
-  const replacements = collectReplacements(sourceFile, outFile, absToRel)
-  return applyReplacements(text, replacements)
-}
-
 export function replacePaths(options: ReplacePathsOptions): ReplacePathsResult {
   const ctx = buildContext(options)
   const resolver = createAliasResolver(ctx)
   const quiet = Boolean(options.quiet)
   const check = Boolean(options.check)
 
-  const files = sync(`${ctx.outPath.replaceAll('\\', '/')}/**/*.{js,jsx,ts,tsx}`, {
-    dot: true,
-    noDir: true,
-  } as { dot: boolean; noDir: boolean }).map(function (x) {
-    return resolve(x)
+  const files = walkOutputFiles(ctx.outPath, [])
+  const prefixes = ctx.aliases.map(function (alias) {
+    return alias.prefix
   })
 
   const changedFiles: string[] = []
@@ -212,8 +189,13 @@ export function replacePaths(options: ReplacePathsOptions): ReplacePathsResult {
   for (let i = 0; i < files.length; i += 1) {
     const file = files[i]
     const text = readFileSync(file, 'utf8')
+
+    if (!hasAnyPrefix(text, prefixes)) {
+      continue
+    }
+
     const prevCount = resolver.getReplaceCount()
-    const newText = replaceAliasInText(text, file, resolver.absToRel)
+    const newText = applyReplacements(text, collectReplacements(text, file, resolver.absToRel))
 
     if (text !== newText) {
       changedFileCount += 1

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs'
 import { dirname, join, relative, resolve } from 'path'
-import { AliasEntry, ResolvedContext } from './types'
+import { AliasEntry, ResolvedContext } from './types.js'
 
 const PROBE_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.mjs', '.cjs', '.mts', '.cts', '.json']
 const STRIP_EXTS = ['.d.ts', '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts', '.json']

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -2,15 +2,32 @@ import { existsSync } from 'fs'
 import { dirname, join, relative, resolve } from 'path'
 import { AliasEntry, ResolvedContext } from './types'
 
-const LOOKUP_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.json']
+const PROBE_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.mjs', '.cjs', '.mts', '.cts', '.json']
+const STRIP_EXTS = ['.d.ts', '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts', '.json']
+const OUTPUT_EXTS = ['.js', '.jsx', '.d.ts', '.mjs', '.cjs']
+
+type ExistsFn = (path: string) => boolean
 
 export function toRelative(from: string, target: string): string {
   const rel = relative(from, target)
   return (rel.startsWith('.') ? rel : `./${rel}`).replace(/\\/g, '/')
 }
 
+function createExistsCache(): ExistsFn {
+  const cache = new Map<string, boolean>()
+  return function (path: string): boolean {
+    const cached = cache.get(path)
+    if (cached !== undefined) {
+      return cached
+    }
+    const result = existsSync(path)
+    cache.set(path, result)
+    return result
+  }
+}
+
 function stripExtension(filePath: string): { base: string; ext: string | undefined } {
-  const ext = LOOKUP_EXTS.find(function (candidate) {
+  const ext = STRIP_EXTS.find(function (candidate) {
     return filePath.endsWith(candidate)
   })
   if (ext) {
@@ -22,49 +39,57 @@ function stripExtension(filePath: string): { base: string; ext: string | undefin
   return { base: filePath, ext: undefined }
 }
 
-function findExistingModule(basePath: string): { path: string; ext: string } | null {
+function hasKnownExtension(filePath: string): boolean {
+  return stripExtension(filePath).ext !== undefined
+}
+
+function stripOutputExtension(filePath: string): string {
+  const ext = OUTPUT_EXTS.find(function (candidate) {
+    return filePath.endsWith(candidate)
+  })
+  return ext ? filePath.substring(0, filePath.length - ext.length) : filePath
+}
+
+function findExistingModule(basePath: string, exists: ExistsFn): { path: string; ext: string } | null {
   const stripped = stripExtension(basePath)
 
-  if (stripped.ext && existsSync(basePath)) {
+  if (stripped.ext && exists(basePath)) {
     return { path: basePath, ext: stripped.ext }
   }
 
-  if (stripped.ext === '.js' && existsSync(`${stripped.base}.ts`)) {
+  if (stripped.ext === '.js' && exists(`${stripped.base}.ts`)) {
     return { path: `${stripped.base}.ts`, ext: '.ts' }
   }
 
-  if (stripped.ext === '.js' && existsSync(`${stripped.base}.tsx`)) {
+  if (stripped.ext === '.js' && exists(`${stripped.base}.tsx`)) {
     return { path: `${stripped.base}.tsx`, ext: '.tsx' }
   }
 
-  for (let i = 0; i < LOOKUP_EXTS.length; i += 1) {
-    const candidate = `${stripped.base}${LOOKUP_EXTS[i]}`
-    if (existsSync(candidate)) {
-      return { path: candidate, ext: LOOKUP_EXTS[i] }
+  for (let i = 0; i < PROBE_EXTS.length; i += 1) {
+    const candidate = `${stripped.base}${PROBE_EXTS[i]}`
+    if (exists(candidate)) {
+      return { path: candidate, ext: PROBE_EXTS[i] }
     }
   }
 
   return null
 }
 
-function sourcePathToOutputPath(
-  sourceFile: string,
-  usingSrcDir: string,
-  outPath: string,
-): string {
-  const rel = relative(usingSrcDir, sourceFile)
-  if (rel.startsWith('..')) {
-    return join(outPath, rel)
-  }
-  return join(outPath, rel)
-}
-
 function mapSourceExtToOutput(sourceFile: string): string {
+  if (sourceFile.endsWith('.d.ts')) {
+    return sourceFile
+  }
   if (sourceFile.endsWith('.tsx')) {
     return `${sourceFile.substring(0, sourceFile.length - 4)}.jsx`
   }
   if (sourceFile.endsWith('.ts')) {
     return `${sourceFile.substring(0, sourceFile.length - 3)}.js`
+  }
+  if (sourceFile.endsWith('.mts')) {
+    return `${sourceFile.substring(0, sourceFile.length - 4)}.mjs`
+  }
+  if (sourceFile.endsWith('.cts')) {
+    return `${sourceFile.substring(0, sourceFile.length - 4)}.cjs`
   }
   return sourceFile
 }
@@ -73,19 +98,18 @@ function findOutputModule(
   sourceModule: { path: string; ext: string },
   usingSrcDir: string,
   outPath: string,
+  exists: ExistsFn,
 ): string | null {
-  const mappedOutput = mapSourceExtToOutput(
-    sourcePathToOutputPath(sourceModule.path, usingSrcDir, outPath),
-  )
+  const mappedOutput = mapSourceExtToOutput(join(outPath, relative(usingSrcDir, sourceModule.path)))
 
-  if (existsSync(mappedOutput)) {
+  if (exists(mappedOutput)) {
     return mappedOutput
   }
 
   const stripped = stripExtension(mappedOutput)
-  for (let i = 0; i < LOOKUP_EXTS.length; i += 1) {
-    const candidate = `${stripped.base}${LOOKUP_EXTS[i]}`
-    if (existsSync(candidate)) {
+  for (let i = 0; i < PROBE_EXTS.length; i += 1) {
+    const candidate = `${stripped.base}${PROBE_EXTS[i]}`
+    if (exists(candidate)) {
       return candidate
     }
   }
@@ -102,6 +126,7 @@ export function createAliasResolver(ctx: ResolvedContext): {
   getReplaceCount: () => number
 } {
   let replaceCount = 0
+  const exists = createExistsCache()
 
   function absToRel(modulePath: string, outFile: string): string {
     const alen = ctx.aliases.length
@@ -125,28 +150,18 @@ export function createAliasResolver(ctx: ResolvedContext): {
       for (let i = 0; i < aliasPaths.length; i += 1) {
         const apath = aliasPaths[i]
         const lookupBase = resolve(apath, modulePathRel)
-        const sourceModule = findExistingModule(lookupBase)
+        const sourceModule = findExistingModule(lookupBase, exists)
 
         if (!sourceModule) {
           continue
         }
 
-        const outputModule = findOutputModule(sourceModule, ctx.usingSrcDir, ctx.outPath)
-        const modulePathEndsWithJs = modulePath.endsWith('.js') || modulePath.endsWith('.jsx')
-        const aliasUsesJs = apath.endsWith('.js') || apath.endsWith('.jsx')
+        const outputModule = findOutputModule(sourceModule, ctx.usingSrcDir, ctx.outPath, exists)
 
-        let targetPath = outputModule || sourceModule.path
+        let targetPath = mapSourceExtToOutput(outputModule || sourceModule.path)
 
-        if (targetPath.endsWith('.ts') || targetPath.endsWith('.tsx')) {
-          targetPath = mapSourceExtToOutput(targetPath)
-        }
-
-        if ((modulePathEndsWithJs || aliasUsesJs) && (targetPath.endsWith('.js') || targetPath.endsWith('.jsx'))) {
-          // keep js extension in relative path for ESM
-        } else if (!modulePathEndsWithJs && targetPath.endsWith('.js')) {
-          targetPath = targetPath.substring(0, targetPath.length - 3)
-        } else if (!modulePathEndsWithJs && targetPath.endsWith('.jsx')) {
-          targetPath = targetPath.substring(0, targetPath.length - 4)
+        if (!hasKnownExtension(modulePath) && !hasKnownExtension(apath)) {
+          targetPath = stripOutputExtension(targetPath)
         }
 
         const rel = toRelative(outFileDir, targetPath)
@@ -172,10 +187,7 @@ export function createAliasResolver(ctx: ResolvedContext): {
   }
 }
 
-export function buildAliases(
-  paths: { [key: string]: string[] },
-  basePath: string,
-): AliasEntry[] {
+export function buildAliases(paths: { [key: string]: string[] }, basePath: string): AliasEntry[] {
   return Object.keys(paths)
     .map(function (alias) {
       return {
@@ -186,6 +198,9 @@ export function buildAliases(
       }
     })
     .filter(function (entry) {
-      return entry.prefix
+      return Boolean(entry.prefix)
+    })
+    .sort(function (a, b) {
+      return b.prefix.length - a.prefix.length
     })
 }

--- a/tests/fixtures/basic-alias/before/dist/index.js
+++ b/tests/fixtures/basic-alias/before/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/basic-alias/before/dist/utils/helper.js
+++ b/tests/fixtures/basic-alias/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/basic-alias/expected/dist/index.js
+++ b/tests/fixtures/basic-alias/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/basic-alias/expected/dist/utils/helper.js
+++ b/tests/fixtures/basic-alias/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/dts-alias/before/dist/index.d.ts
+++ b/tests/fixtures/dts-alias/before/dist/index.d.ts
@@ -1,0 +1,2 @@
+import { User } from '@models/user'
+export declare const user: User

--- a/tests/fixtures/dts-alias/before/dist/models/user.d.ts
+++ b/tests/fixtures/dts-alias/before/dist/models/user.d.ts
@@ -1,0 +1,3 @@
+export interface User {
+  id: number
+}

--- a/tests/fixtures/dts-alias/expected/dist/index.d.ts
+++ b/tests/fixtures/dts-alias/expected/dist/index.d.ts
@@ -1,0 +1,2 @@
+import { User } from './models/user'
+export declare const user: User

--- a/tests/fixtures/dts-alias/expected/dist/models/user.d.ts
+++ b/tests/fixtures/dts-alias/expected/dist/models/user.d.ts
@@ -1,0 +1,3 @@
+export interface User {
+  id: number
+}

--- a/tests/fixtures/dts-alias/src/index.ts
+++ b/tests/fixtures/dts-alias/src/index.ts
@@ -1,0 +1,3 @@
+import { User } from '@models/user'
+
+export const user: User = { id: 1 }

--- a/tests/fixtures/dts-alias/src/models/user.ts
+++ b/tests/fixtures/dts-alias/src/models/user.ts
@@ -1,0 +1,3 @@
+export interface User {
+  id: number
+}

--- a/tests/fixtures/dts-alias/tsconfig.json
+++ b/tests/fixtures/dts-alias/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@models/*": ["src/models/*"]
+    }
+  }
+}

--- a/tests/fixtures/dynamic-import/before/dist/index.js
+++ b/tests/fixtures/dynamic-import/before/dist/index.js
@@ -1,0 +1,3 @@
+export function load() {
+  return import('@utils/helper')
+}

--- a/tests/fixtures/dynamic-import/before/dist/utils/helper.js
+++ b/tests/fixtures/dynamic-import/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/dynamic-import/expected/dist/index.js
+++ b/tests/fixtures/dynamic-import/expected/dist/index.js
@@ -1,0 +1,3 @@
+export function load() {
+  return import('./utils/helper')
+}

--- a/tests/fixtures/dynamic-import/expected/dist/utils/helper.js
+++ b/tests/fixtures/dynamic-import/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/dynamic-import/src/index.ts
+++ b/tests/fixtures/dynamic-import/src/index.ts
@@ -1,0 +1,3 @@
+export function load() {
+  return import('@utils/helper')
+}

--- a/tests/fixtures/dynamic-import/src/utils/helper.ts
+++ b/tests/fixtures/dynamic-import/src/utils/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/dynamic-import/tsconfig.json
+++ b/tests/fixtures/dynamic-import/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}

--- a/tests/fixtures/esm-js-extension/before/dist/index.js
+++ b/tests/fixtures/esm-js-extension/before/dist/index.js
@@ -1,0 +1,5 @@
+import { serviceValue } from '@service'
+
+export function main() {
+  return serviceValue()
+}

--- a/tests/fixtures/esm-js-extension/before/dist/service/index.service.js
+++ b/tests/fixtures/esm-js-extension/before/dist/service/index.service.js
@@ -1,0 +1,3 @@
+export function serviceValue() {
+  return 'service'
+}

--- a/tests/fixtures/esm-js-extension/expected/dist/index.js
+++ b/tests/fixtures/esm-js-extension/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { serviceValue } from './service/index.service.js'
+
+export function main() {
+  return serviceValue()
+}

--- a/tests/fixtures/esm-js-extension/expected/dist/service/index.service.js
+++ b/tests/fixtures/esm-js-extension/expected/dist/service/index.service.js
@@ -1,0 +1,3 @@
+export function serviceValue() {
+  return 'service'
+}

--- a/tests/fixtures/extends-array/before/dist/index.js
+++ b/tests/fixtures/extends-array/before/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-array/before/dist/utils/helper.js
+++ b/tests/fixtures/extends-array/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/extends-array/expected/dist/index.js
+++ b/tests/fixtures/extends-array/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-array/expected/dist/utils/helper.js
+++ b/tests/fixtures/extends-array/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/extends-array/src/index.ts
+++ b/tests/fixtures/extends-array/src/index.ts
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-array/src/utils/helper.ts
+++ b/tests/fixtures/extends-array/src/utils/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/extends-array/tsconfig.base.json
+++ b/tests/fixtures/extends-array/tsconfig.base.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}

--- a/tests/fixtures/extends-array/tsconfig.json
+++ b/tests/fixtures/extends-array/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["./tsconfig.base.json"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  }
+}

--- a/tests/fixtures/extends-local/before/dist/index.js
+++ b/tests/fixtures/extends-local/before/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-local/before/dist/utils/helper.js
+++ b/tests/fixtures/extends-local/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/extends-local/expected/dist/index.js
+++ b/tests/fixtures/extends-local/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-local/expected/dist/utils/helper.js
+++ b/tests/fixtures/extends-local/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/extends-npm/before/dist/index.js
+++ b/tests/fixtures/extends-npm/before/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-npm/before/dist/utils/helper.js
+++ b/tests/fixtures/extends-npm/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/extends-npm/expected/dist/index.js
+++ b/tests/fixtures/extends-npm/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/extends-npm/expected/dist/utils/helper.js
+++ b/tests/fixtures/extends-npm/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/tests/fixtures/mjs-output/before/dist/index.mjs
+++ b/tests/fixtures/mjs-output/before/dist/index.mjs
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/mjs-output/before/dist/utils/helper.mjs
+++ b/tests/fixtures/mjs-output/before/dist/utils/helper.mjs
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/mjs-output/expected/dist/index.mjs
+++ b/tests/fixtures/mjs-output/expected/dist/index.mjs
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/mjs-output/expected/dist/utils/helper.mjs
+++ b/tests/fixtures/mjs-output/expected/dist/utils/helper.mjs
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/mjs-output/src/index.ts
+++ b/tests/fixtures/mjs-output/src/index.ts
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/mjs-output/src/utils/helper.ts
+++ b/tests/fixtures/mjs-output/src/utils/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/mjs-output/tsconfig.json
+++ b/tests/fixtures/mjs-output/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}

--- a/tests/fixtures/no-baseurl/before/dist/index.js
+++ b/tests/fixtures/no-baseurl/before/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/no-baseurl/before/dist/utils/helper.js
+++ b/tests/fixtures/no-baseurl/before/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/no-baseurl/expected/dist/index.js
+++ b/tests/fixtures/no-baseurl/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { helper } from './utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/no-baseurl/expected/dist/utils/helper.js
+++ b/tests/fixtures/no-baseurl/expected/dist/utils/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/no-baseurl/src/index.ts
+++ b/tests/fixtures/no-baseurl/src/index.ts
@@ -1,0 +1,5 @@
+import { helper } from '@utils/helper'
+
+export function main() {
+  return helper()
+}

--- a/tests/fixtures/no-baseurl/src/utils/helper.ts
+++ b/tests/fixtures/no-baseurl/src/utils/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 1
+}

--- a/tests/fixtures/no-baseurl/tsconfig.json
+++ b/tests/fixtures/no-baseurl/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@utils/*": ["./src/utils/*"]
+    }
+  }
+}

--- a/tests/fixtures/nx-outdir/before/dist/apps/api/index.js
+++ b/tests/fixtures/nx-outdir/before/dist/apps/api/index.js
@@ -1,0 +1,5 @@
+import { dtoValue } from '@lib/index'
+
+export function main() {
+  return dtoValue()
+}

--- a/tests/fixtures/nx-outdir/before/dist/libs/dto/src/index.js
+++ b/tests/fixtures/nx-outdir/before/dist/libs/dto/src/index.js
@@ -1,0 +1,5 @@
+function dtoValue() {
+  return 'dto'
+}
+
+module.exports = { dtoValue }

--- a/tests/fixtures/nx-outdir/expected/dist/apps/api/index.js
+++ b/tests/fixtures/nx-outdir/expected/dist/apps/api/index.js
@@ -1,0 +1,5 @@
+import { dtoValue } from '../../../libs/dto/src/index'
+
+export function main() {
+  return dtoValue()
+}

--- a/tests/fixtures/nx-outdir/expected/dist/libs/dto/src/index.js
+++ b/tests/fixtures/nx-outdir/expected/dist/libs/dto/src/index.js
@@ -1,0 +1,5 @@
+function dtoValue() {
+  return 'dto'
+}
+
+module.exports = { dtoValue }

--- a/tests/fixtures/pdf-js-in-path/before/dist/index.js
+++ b/tests/fixtures/pdf-js-in-path/before/dist/index.js
@@ -1,0 +1,5 @@
+import { pdfHelper } from '@lib/a.js'
+
+export function main() {
+  return pdfHelper()
+}

--- a/tests/fixtures/pdf-js-in-path/before/dist/pdf.js/a.js
+++ b/tests/fixtures/pdf-js-in-path/before/dist/pdf.js/a.js
@@ -1,0 +1,3 @@
+export function pdfHelper() {
+  return 'pdf'
+}

--- a/tests/fixtures/pdf-js-in-path/expected/dist/index.js
+++ b/tests/fixtures/pdf-js-in-path/expected/dist/index.js
@@ -1,0 +1,5 @@
+import { pdfHelper } from './pdf.js/a.js'
+
+export function main() {
+  return pdfHelper()
+}

--- a/tests/fixtures/pdf-js-in-path/expected/dist/pdf.js/a.js
+++ b/tests/fixtures/pdf-js-in-path/expected/dist/pdf.js/a.js
@@ -1,0 +1,3 @@
+export function pdfHelper() {
+  return 'pdf'
+}

--- a/tests/fixtures/require-syntax/before/dist/index.js
+++ b/tests/fixtures/require-syntax/before/dist/index.js
@@ -1,0 +1,7 @@
+const { helper } = require('@utils/helper')
+
+function main() {
+  return helper()
+}
+
+module.exports = { main }

--- a/tests/fixtures/require-syntax/before/dist/utils/helper.js
+++ b/tests/fixtures/require-syntax/before/dist/utils/helper.js
@@ -1,0 +1,5 @@
+function helper() {
+  return 'helper'
+}
+
+module.exports = { helper }

--- a/tests/fixtures/require-syntax/expected/dist/index.js
+++ b/tests/fixtures/require-syntax/expected/dist/index.js
@@ -1,0 +1,7 @@
+const { helper } = require('./utils/helper')
+
+function main() {
+  return helper()
+}
+
+module.exports = { main }

--- a/tests/fixtures/require-syntax/expected/dist/utils/helper.js
+++ b/tests/fixtures/require-syntax/expected/dist/utils/helper.js
@@ -1,0 +1,5 @@
+function helper() {
+  return 'helper'
+}
+
+module.exports = { helper }

--- a/tests/missing-config/tsconfig.build.json
+++ b/tests/missing-config/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}

--- a/tests/run-fixtures.ts
+++ b/tests/run-fixtures.ts
@@ -139,6 +139,19 @@ test('quiet mode suppresses summary output', function () {
   assert.strictEqual(result.stdout.trim(), '')
 })
 
+test('missing tsconfig suggests available configs', function () {
+  const fixtureDir = path.join(__dirname, 'missing-config')
+
+  const result = spawnSync(process.execPath, [cliPath], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+  })
+
+  assert.strictEqual(result.status, 1)
+  assert.match(result.stderr, /tsconfig not found/)
+  assert.match(result.stderr, /--project tsconfig\.build\.json/)
+})
+
 test('programmatic api replaces paths', function () {
   const fixtureDir = path.join(fixturesRoot, 'basic-alias')
   const beforeDir = path.join(fixtureDir, 'before', 'dist')


### PR DESCRIPTION
## Summary

Performance and developer-experience overhaul for v1.0.0, with a minimal breaking surface (Node ≥ 18; dynamic `import()` specifiers are now rewritten).

- **Parsing:** replace the per-file TypeScript AST walk with `ts.preProcessFile` (scanner-only) — 4.5x faster per-file parse, and it catches dynamic `import()` specifiers the AST walk silently missed. Files without alias prefixes skip parsing entirely.
- **Filesystem:** memoize `existsSync` — 12,000 → 200 syscalls on a 2,000-file benchmark; core loop 198ms → 121ms (−39%).
- **Dependencies:** drop `globby` (own recursive walker), `commander` (Node `util.parseArgs`), and `json5` (`ts.readConfigFile` + `parseJsonConfigFileContent`). `typescript` is now the only runtime dependency. TS-native config parsing also gains `extends` arrays (TS 5.0) and `paths`-without-`baseUrl` support.
- **Fixes:** `.d.ts` aliases no longer map to broken `.js` paths; `.mjs/.cjs/.mts/.cts` handled; aliases match longest-prefix-first (mirrors TS semantics); CLI prints one-line errors instead of stack traces; a missing tsconfig error names the exact `--project` flag to run.
- **Packaging:** `engines: node >=18`, `sideEffects: false`, `types` conditions in `exports`.
- `bench/` scripts included so the performance claims are reproducible.

## Test plan

- [x] `pnpm test` — 16/16 green (10 existing + 5 new fixtures: dynamic-import, extends-array, no-baseUrl, dts-alias, mjs-output, plus the missing-config hint test)
- [x] Benchmark before/after: `pnpm exec tsx bench/generate.ts 2000 && node bench/measure.cjs`
- [x] Lint clean (`eslint src`)
- [ ] CI on this PR
- [ ] Smoke-test the packed tarball (`npm pack` + install into a scratch project) before `pnpm run release`

Made with [Cursor](https://cursor.com)